### PR TITLE
mesh: Fix GCC 8 compiler warning

### DIFF
--- a/src/mesh/model/dot11s/ie-dot11s-beacon-timing.cc
+++ b/src/mesh/model/dot11s/ie-dot11s-beacon-timing.cc
@@ -206,7 +206,7 @@ IeBeaconTiming::operator== (WifiInformationElement const & a) const
         }
       return true;
     }
-  catch (std::bad_cast)
+  catch (std::bad_cast&)
     {
       return false;
     }


### PR DESCRIPTION
An error occurs when compiling mesh. This error has been fixed in the latest ns3 version, but not here. This update fixes the compiling error when running `./waf build`.